### PR TITLE
Fix pathing in dockerfile for start.sh

### DIFF
--- a/run/docker/Dockerfile
+++ b/run/docker/Dockerfile
@@ -17,6 +17,9 @@ RUN python manage.py collectstatic --noinput
 
 EXPOSE 8000
 
+RUN apt-get update && apt-get install -y dos2unix 
+RUN dos2unix /srv/run/docker/start.sh
 RUN chmod +x /srv/run/docker/start.sh
+
 
 CMD ["/srv/run/docker/start.sh"]


### PR DESCRIPTION
Relates to
- #16 

This fix ensures that the start.sh is indeed a properly Linux-supported file when trying to run a container