### PR TITLE
Add conditional installation of dos2unix to handle CRLF line endings

### DIFF
--- a/run/docker/Dockerfile
+++ b/run/docker/Dockerfile
@@ -17,6 +17,16 @@ RUN python manage.py collectstatic --noinput
 
 EXPOSE 8000
 
+# Install dos2unix only if needed and convert line endings if necessary
+RUN if file /srv/run/docker/start.sh | grep -q "CRLF"; then \
+    apt-get update && apt-get install -y dos2unix && \
+    dos2unix /srv/run/docker/start.sh && \
+    apt-get remove -y dos2unix && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*; \
+    fi
+
 RUN chmod +x /srv/run/docker/start.sh
 
 CMD ["/srv/run/docker/start.sh"]


### PR DESCRIPTION
This PR introduces a conditional installation of dos2unix to resolve issues related to CRLF line endings when running docker compose on Windows. By ensuring dos2unix is available when needed, this fix prevents unexpected line-ending problems, improving cross-platform compatibility.
Changes:
- Add logic to install dos2unix only when necessary.
- Ensure scripts handle CRLF line endings correctly in Windows environments.
Testing:
- Confirmed docker compose runs without line-ending issues post-installation
